### PR TITLE
add sudo to rm ~/rpmbuild

### DIFF
--- a/scripts/buildRpm.sh
+++ b/scripts/buildRpm.sh
@@ -11,7 +11,7 @@ VERSION="1.$GIT_VERSION"
 
 echo "Building $PACKAGE, type: $BUILD_TYPE, version: $VERSION"
 
-rm -rf ~/rpmbuild
+sudo rm -rf ~/rpmbuild
 rpmdev-setuptree
 cp packaging/$PACKAGE.spec ~/rpmbuild/SPECS
 rm -f $PACKAGE-$VERSION.tar.gz


### PR DESCRIPTION
Changing the remove line to run as root, since some files in here are now owned by root.

codecoverage - https://github.com/logrhythm/CodeCoverage/pull/13
Stopwatch - https://github.com/logrhythm/StopWatch/pull/31
Nm-tools - https://github.com/logrhythm/nm-tools/pull/5
Nm-protobuffers - https://github.com/logrhythm/nm-protobuffers/pull/6
Nm-stats - https://github.com/logrhythm/nm-stats/pull/2
Nm-build-version - https://github.com/logrhythm/nm-build-version/pull/2
Nm-setup - https://github.com/logrhythm/nm-setup/pull/10
Syslog-sender - https://github.com/logrhythm/syslog-sender/pull/2
Nm-lua-executer - https://github.com/logrhythm/nm-lua-executer/pull/5
inverted-index-file - https://github.com/logrhythm/inverted-index-file/pull/3
Nm-dpi - https://github.com/logrhythm/nm-dpi/pull/13
Probe-transmogrifier - https://github.com/logrhythm/probe-transmogrifier/pull/2
Nm-system-rules - https://github.com/logrhythm/nm-system-rules/pull/1
Nm-phone-home - https://github.com/logrhythm/nm-phone-home/pull/1
Nm-core - https://github.com/logrhythm/nm-core/pull/39
Kibana - https://github.com/logrhythm/kibana/pull/97
Nm-web-app - https://github.com/logrhythm/nm-web-app/pull/45
Nm-docs - https://github.com/logrhythm/nm-docs/pull/12